### PR TITLE
FEAT: Allow customed comment content

### DIFF
--- a/core/service.py
+++ b/core/service.py
@@ -225,12 +225,13 @@ class PostService:
         logger.info(f"已点赞 → {post.name}")
 
 
-    async def comment_posts(self, post: Post):
+    async def comment_posts(self, post: Post, content: str | None = None):
         """评论帖子"""
         if not post.tid:
             raise ValueError("帖子 tid 为空")
 
-        content = await self.llm.generate_comment(post)
+        if content is None:
+            content = await self.llm.generate_comment(post)
         if not content:
             raise ValueError("生成评论内容为空")
 
@@ -251,7 +252,7 @@ class PostService:
         await self.db.save(post)
         logger.info(f"评论 → {post.name}")
 
-    async def reply_comment(self, post: Post, index: int):
+    async def reply_comment(self, post: Post, index: int, content: str | None = None):
         """回复评论（自动排除自己的评论）"""
 
         if not post.tid:
@@ -273,7 +274,8 @@ class PostService:
         comment = other_comments[index]
 
         # 生成回复
-        content = await self.llm.generate_reply(post, comment)
+        if content is None:
+            content = await self.llm.generate_reply(post, comment)
         if not content:
             raise ValueError("生成回复内容为空")
 

--- a/main.py
+++ b/main.py
@@ -249,7 +249,7 @@ class QzonePlugin(Star):
             yield event.plain_result(f"稿件#{post_id}不存在")
             return
         try:
-            await self.service.reply_comment(post, index=comment_index)
+            await self.service.reply_comment(post, index=comment_index, content=reply_text)
             await self.sender.send_post(event, post, message="已回复评论")
         except Exception as e:
             await event.send(event.plain_result(str(e)))
@@ -300,6 +300,7 @@ class QzonePlugin(Star):
         pos: int = 0,
         like: bool = False,
         reply: bool = False,
+        comment_text: str | None = None,
     ):
         """
         查看、点赞、评论某位用户QQ空间的某条说说、动态
@@ -308,6 +309,7 @@ class QzonePlugin(Star):
             pos(number): 要查询的说说序号, 默认为0表示最新
             like(boolean): 是否点赞
             reply(boolean): 是否评论
+            comment_text(string): 自定义评论内容（若提供则直接使用此内容评论，否则自动生成）
         """
         try:
             user_id = user_id or event.get_sender_id()
@@ -329,11 +331,11 @@ class QzonePlugin(Star):
             msg = ""
 
             if like and reply:
-                await self.service.comment_posts(post)
+                await self.service.comment_posts(post, content=comment_text)
                 await self.service.like_posts(post)
                 msg = "已评论并点赞"
             elif reply:
-                await self.service.comment_posts(post)
+                await self.service.comment_posts(post, content=comment_text)
                 msg = "已评论"
             elif like:
                 await self.service.like_posts(post)
@@ -368,3 +370,12 @@ class QzonePlugin(Star):
             return "已发布说说到QQ空间: \n" + post.text + "\n" + "\n".join(post.images)
         except Exception as e:
             return str(e)
+
+    @filter.llm_tool()
+    async def llm_reply_comment(
+        self, event, user_id=None, pos=0, comment_index=-1,
+        reply_text: str | None = None,
+    ):
+        """回复某条说说的某条评论"""
+        # 调用 service.reply_comment 并传入 reply_text
+        await self.service.reply_comment(post, index=comment_index, content=reply_text)

--- a/main.py
+++ b/main.py
@@ -249,7 +249,7 @@ class QzonePlugin(Star):
             yield event.plain_result(f"稿件#{post_id}不存在")
             return
         try:
-            await self.service.reply_comment(post, index=comment_index, content=reply_text)
+            await self.service.reply_comment(post, index=comment_index)
             await self.sender.send_post(event, post, message="已回复评论")
         except Exception as e:
             await event.send(event.plain_result(str(e)))


### PR DESCRIPTION
允许传入自定义的评论和回复的内容
使得用户可以指定大模型评论或回复时的内容
或在对话时让大模型生成评论或回复时的内容，使得评论或回复内容有上下文关联

## Summary by Sourcery

允许为 QQ 空间评论和回复指定自定义内容，并暴露一个用于回复帖子中特定评论的新 LLM 工具。

New Features:
- 支持在 LLM 对 QQ 空间帖子进行评论时传入自定义评论文本。
- 添加一个 LLM 工具入口点，用于回复 QQ 空间帖子中的特定评论，并可选传入自定义回复文本。

Enhancements:
- 更新评论与回复服务，使其仅在未提供自定义文本时才回退使用 LLM 生成的内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow specifying custom content for QQ Space comments and replies and expose a new LLM tool for replying to a specific comment on a post.

New Features:
- Support passing custom comment text when the LLM comments on a QQ Space post.
- Add an LLM tool entry point to reply to a specific comment on a QQ Space post with optional custom reply text.

Enhancements:
- Update comment and reply services to fall back to LLM-generated content only when no custom text is provided.

</details>