### PR TITLE
pref：llm跟随当前人格

### DIFF
--- a/core/llm_action.py
+++ b/core/llm_action.py
@@ -1,3 +1,4 @@
+import copy
 import random
 import re
 from typing import Any
@@ -13,6 +14,10 @@ class LLMAction:
     def __init__(self, config: PluginConfig):
         self.cfg = config
         self.context = config.context
+
+    @staticmethod
+    def _join_prompt_parts(*parts: str) -> str:
+        return "\n\n".join(part.strip() for part in parts if part and part.strip())
 
     def _build_context(
         self, round_messages: list[dict[str, Any]]
@@ -58,6 +63,114 @@ class LLMAction:
         return contexts
 
     @staticmethod
+    def _get_event_umo(event: Any | None) -> str | None:
+        umo = getattr(event, "unified_msg_origin", None)
+        return str(umo) if umo else None
+
+    def _get_event_platform_name(self, event: Any | None) -> str:
+        getter = getattr(event, "get_platform_name", None)
+        if callable(getter):
+            try:
+                platform_name = getter()
+            except Exception:
+                platform_name = None
+            if platform_name:
+                return str(platform_name)
+
+        umo = self._get_event_umo(event)
+        if umo and ":" in umo:
+            return umo.split(":", 1)[0]
+        return ""
+
+    def _get_provider_settings(self, event: Any | None) -> dict[str, Any]:
+        umo = self._get_event_umo(event)
+        cfg = self.context.get_config(umo) if umo else self.context.get_config()
+        provider_settings = cfg.get("provider_settings", {})
+        return provider_settings if isinstance(provider_settings, dict) else {}
+
+    def _get_provider(
+        self, provider_id: str, event: Any | None = None
+    ) -> Provider | None:
+        provider = self.context.get_provider_by_id(provider_id) if provider_id else None
+        if isinstance(provider, Provider):
+            return provider
+
+        try:
+            umo = self._get_event_umo(event)
+            provider = (
+                self.context.get_using_provider(umo)
+                if umo
+                else self.context.get_using_provider()
+            )
+        except Exception as e:
+            logger.error(f"获取当前会话的 LLM 提供商失败: {e}")
+            return None
+
+        return provider if isinstance(provider, Provider) else None
+
+    async def _get_persona_context(
+        self, event: Any | None
+    ) -> tuple[str, list[dict[str, Any]]]:
+        if not event:
+            return "", []
+
+        umo = self._get_event_umo(event)
+        if not umo:
+            return "", []
+
+        try:
+            conversation_persona_id = None
+            cid = await self.context.conversation_manager.get_curr_conversation_id(umo)
+            if cid:
+                conversation = await self.context.conversation_manager.get_conversation(
+                    umo, cid
+                )
+                if conversation:
+                    conversation_persona_id = conversation.persona_id
+
+            (
+                persona_id,
+                persona,
+                _,
+                _,
+            ) = await self.context.persona_manager.resolve_selected_persona(
+                umo=umo,
+                conversation_persona_id=conversation_persona_id,
+                platform_name=self._get_event_platform_name(event),
+                provider_settings=self._get_provider_settings(event),
+            )
+
+            if not persona and persona_id:
+                persona = self.context.persona_manager.get_persona_v3_by_id(persona_id)
+
+            if not persona:
+                return "", []
+
+            persona_prompt = str(persona.get("prompt") or "").strip()
+            begin_dialogs = copy.deepcopy(persona.get("_begin_dialogs_processed") or [])
+            return persona_prompt, begin_dialogs
+        except Exception as e:
+            logger.warning(f"解析当前会话人格失败，将回退到插件默认任务提示词: {e}")
+            return "", []
+
+    async def _build_request_context(
+        self,
+        *,
+        event: Any | None,
+        task_prompt: str,
+        contexts: list[dict[str, Any]] | None = None,
+    ) -> tuple[str, list[dict[str, Any]]]:
+        persona_prompt, persona_contexts = await self._get_persona_context(event)
+        system_prompt = self._join_prompt_parts(
+            "# Persona Instructions\n\n" + persona_prompt if persona_prompt else "",
+            task_prompt,
+        )
+        merged_contexts = [*persona_contexts]
+        if contexts:
+            merged_contexts.extend(contexts)
+        return system_prompt, merged_contexts
+
+    @staticmethod
     def extract_content(raw: str) -> str:
         start_marker = '"""'
         end_marker = '"""'
@@ -68,13 +181,14 @@ class LLMAction:
         return ""
 
     async def generate_post(
-        self, group_id: str = "", topic: str | None = None
+        self,
+        group_id: str = "",
+        topic: str | None = None,
+        *,
+        event: Any | None = None,
     ) -> str | None:
         """生成帖子"""
-        provider = (
-            self.context.get_provider_by_id(self.cfg.llm.post_provider_id)
-            or self.context.get_using_provider()
-        )
+        provider = self._get_provider(self.cfg.llm.post_provider_id, event)
         if not isinstance(provider, Provider):
             raise RuntimeError("未配置用于文本生成任务的 LLM 提供商")
 
@@ -97,11 +211,17 @@ class LLMAction:
             contexts = await self._get_msg_contexts(group_id)
         # TODO: 更多模式
 
-        # 系统提示，要求使用三对双引号包裹正文
-        system_prompt = (
-            f"# 写作主题：{topic or '从聊天内容中选一个主题'}\n\n"
+        task_prompt = self._join_prompt_parts(
+            f"# 写作主题：{topic or '从聊天内容中选一个主题'}",
+            self.cfg.llm.post_prompt,
             "# 输出格式要求：\n"
-            '- 使用三对双引号（"""）将正文内容包裹起来。\n\n' + self.cfg.llm.post_prompt
+            '- 使用三对双引号（"""）将正文内容包裹起来。\n'
+            "- 只输出最终可发布的说说正文，不要附带解释、标题或额外说明。",
+        )
+        system_prompt, contexts = await self._build_request_context(
+            event=event,
+            task_prompt=task_prompt,
+            contexts=contexts,
         )
 
         logger.debug(f"{system_prompt}\n\n{contexts}")
@@ -120,12 +240,11 @@ class LLMAction:
         except Exception as e:
             raise ValueError(f"LLM 调用失败：{e}")
 
-    async def generate_comment(self, post: Post) -> str | None:
+    async def generate_comment(
+        self, post: Post, *, event: Any | None = None
+    ) -> str | None:
         """根据帖子内容生成评论"""
-        provider = (
-            self.context.get_provider_by_id(self.cfg.llm.comment_provider_id)
-            or self.context.get_using_provider()
-        )
+        provider = self._get_provider(self.cfg.llm.comment_provider_id, event)
         if not isinstance(provider, Provider):
             logger.error("未配置用于文本生成任务的 LLM 提供商")
             return None
@@ -135,11 +254,19 @@ class LLMAction:
                 content += f"\n[转发]\n{post.rt_con}"
 
             prompt = f"\n[帖子内容]：\n{content}"
+            system_prompt, contexts = await self._build_request_context(
+                event=event,
+                task_prompt=self._join_prompt_parts(
+                    self.cfg.llm.comment_prompt,
+                    "# 输出要求：\n- 只输出最终评论内容，不要解释，不要分点，不要添加额外前缀。",
+                ),
+            )
 
             logger.debug(prompt)
             llm_response = await provider.text_chat(
-                system_prompt=self.cfg.llm.comment_prompt,
+                system_prompt=system_prompt,
                 prompt=prompt,
+                contexts=contexts,
                 image_urls=post.images,
             )
             comment = re.sub(r"[\s\u3000]+", "", llm_response.completion_text).rstrip(
@@ -151,12 +278,15 @@ class LLMAction:
         except Exception as e:
             raise ValueError(f"LLM 调用失败：{e}")
 
-    async def generate_reply(self, post: Post, comment: Comment) -> str | None:
+    async def generate_reply(
+        self,
+        post: Post,
+        comment: Comment,
+        *,
+        event: Any | None = None,
+    ) -> str | None:
         """根据评论内容生成回复"""
-        provider = (
-            self.context.get_provider_by_id(self.cfg.llm.reply_provider_id)
-            or self.context.get_using_provider()
-        )
+        provider = self._get_provider(self.cfg.llm.reply_provider_id, event)
         if not isinstance(provider, Provider):
             logger.error("未配置用于文本生成任务的 LLM 提供商")
             return None
@@ -167,9 +297,18 @@ class LLMAction:
 
             prompt = f"\n## 帖子内容\n{content}"
             prompt += f"\n## 要回复的评论\n{comment.nickname}：{comment.content}"
+            system_prompt, contexts = await self._build_request_context(
+                event=event,
+                task_prompt=self._join_prompt_parts(
+                    self.cfg.llm.reply_prompt,
+                    "# 输出要求：\n- 只输出最终回复内容，不要解释，不要分点，不要添加额外前缀。",
+                ),
+            )
             logger.debug(prompt)
             llm_response = await provider.text_chat(
-                system_prompt=self.cfg.llm.reply_prompt, prompt=prompt
+                system_prompt=system_prompt,
+                prompt=prompt,
+                contexts=contexts,
             )
             reply = re.sub(r"[\s\u3000]+", "", llm_response.completion_text).rstrip(
                 "。"

--- a/core/service.py
+++ b/core/service.py
@@ -2,6 +2,9 @@ import time
 from typing import Any
 
 from astrbot.api import logger
+from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
+    AiocqhttpMessageEvent,
+)
 
 from .db import PostDB
 from .llm_action import LLMAction
@@ -224,12 +227,14 @@ class PostService:
         await self.qzone.like(post)
         logger.info(f"已点赞 → {post.name}")
 
-    async def comment_posts(self, post: Post):
+    async def comment_posts(
+        self, post: Post, event: AiocqhttpMessageEvent | None = None
+    ):
         """评论帖子"""
         if not post.tid:
             raise ValueError("帖子 tid 为空")
 
-        content = await self.llm.generate_comment(post)
+        content = await self.llm.generate_comment(post, event=event)
         if not content:
             raise ValueError("生成评论内容为空")
 
@@ -250,7 +255,12 @@ class PostService:
         await self.db.save(post)
         logger.info(f"评论 → {post.name}")
 
-    async def reply_comment(self, post: Post, index: int):
+    async def reply_comment(
+        self,
+        post: Post,
+        index: int,
+        event: AiocqhttpMessageEvent | None = None,
+    ):
         """回复评论（自动排除自己的评论）"""
 
         if not post.tid:
@@ -272,7 +282,7 @@ class PostService:
         comment = other_comments[index]
 
         # 生成回复
-        content = await self.llm.generate_reply(post, comment)
+        content = await self.llm.generate_reply(post, comment, event=event)
         if not content:
             raise ValueError("生成回复内容为空")
 

--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ class QzonePlugin(Star):
             )
             for post in posts:
                 try:
-                    await self.service.comment_posts(post)
+                    await self.service.comment_posts(post, event=event)
                     if self.cfg.trigger.like_when_comment:
                         await self.service.like_posts(post)
                     await self.sender.send_post(
@@ -158,7 +158,7 @@ class QzonePlugin(Star):
         posts = await self._get_posts(event, no_commented=True, no_self=True)
         for post in posts:
             try:
-                await self.service.comment_posts(post)
+                await self.service.comment_posts(post, event=event)
                 msg = "已评论"
                 if self.cfg.trigger.like_when_comment:
                     await self.service.like_posts(post)
@@ -201,7 +201,9 @@ class QzonePlugin(Star):
         group_id = event.get_group_id()
         topic = event.message_str.partition(" ")[2]
         try:
-            text = await self.llm.generate_post(group_id=group_id, topic=topic)
+            text = await self.llm.generate_post(
+                group_id=group_id, topic=topic, event=event
+            )
         except Exception as e:
             yield event.plain_result(str(e))
             logger.error(e)
@@ -243,7 +245,7 @@ class QzonePlugin(Star):
             yield event.plain_result(f"稿件#{post_id}不存在")
             return
         try:
-            await self.service.reply_comment(post, index=comment_index)
+            await self.service.reply_comment(post, index=comment_index, event=event)
             await self.sender.send_post(event, post, message="已回复评论")
         except Exception as e:
             await event.send(event.plain_result(str(e)))
@@ -323,11 +325,11 @@ class QzonePlugin(Star):
             msg = ""
 
             if like and reply:
-                await self.service.comment_posts(post)
+                await self.service.comment_posts(post, event=event)
                 await self.service.like_posts(post)
                 msg = "已评论并点赞"
             elif reply:
-                await self.service.comment_posts(post)
+                await self.service.comment_posts(post, event=event)
                 msg = "已评论"
             elif like:
                 await self.service.like_posts(post)


### PR DESCRIPTION
## Summary by Sourcery

使由 LLM 生成的帖子、评论和回复遵循由触发事件派生的当前会话人物设定（persona）和提供方（provider）。

新功能：
- 在生成帖子、评论和回复时，应用当前激活的会话人物设定及其对话前上下文（pre-dialog context）。
- 当未显式配置 provider ID 时，允许 LLM 提供方选择回退到该事件所属会话当前正在使用的提供方。

增强内容：
- 通过共享的辅助方法统一构建系统提示词和上下文，以组合人物设定说明、任务提示词以及历史上下文。
- 将原始消息事件贯穿到服务层和主入口点，使下游的 LLM 操作能够推断人物设定、平台和提供方配置。
- 收紧 LLM 输出要求，确保生成内容仅包含最终可发布文本，而不包含额外解释或格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make LLM-generated posts, comments, and replies follow the current conversation persona and provider derived from the triggering event.

New Features:
- Apply the active conversation persona and its pre-dialog context when generating posts, comments, and replies.
- Allow LLM provider selection to fall back to the provider currently in use for the event's conversation when no explicit provider ID is configured.

Enhancements:
- Unify construction of system prompts and contexts via shared helpers to combine persona instructions, task prompts, and historical contexts.
- Thread the originating message event through service and main entrypoints so downstream LLM actions can infer persona, platform, and provider settings.
- Tighten LLM output requirements so generated content only contains the final publishable text without extra explanation or formatting.

</details>