### PR TITLE
修复 qzone 插件初始化时误删 AstrBot 非纯数字管理员 ID 的问题

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -188,27 +188,24 @@ class PluginConfig(ConfigNode):
             zoneinfo.ZoneInfo(tz) if tz else zoneinfo.ZoneInfo("Asia/Shanghai")
         )
 
-        self.admins_id: list[str] = context.get_config().get("admins_id", [])
+        self.admins_id = self._numeric_ids(context.get_config().get("admins_id", []))
         self._normalize_id()
         self.admin_id = self.admins_id[0] if self.admins_id else None
         self.save_config()
 
         self.client: CQHttp | None = None
 
+    @staticmethod
+    def _numeric_ids(ids: list[Any] | None) -> list[str]:
+        return [s for s in map(str, ids or []) if s.isdigit()]
+
     def _normalize_id(self):
         """仅保留纯数字ID"""
         for ids in [
-            self.admins_id,
             self.source.ignore_groups,
             self.source.ignore_users,
         ]:
-            normalized = []
-            for raw in ids:
-                s = str(raw)
-                if s.isdigit():
-                    normalized.append(s)
-            ids.clear()
-            ids.extend(normalized)
+            ids[:] = self._numeric_ids(ids)
 
     def append_ignore_users(self, uid: str | list[str]):
         uids = [uid] if isinstance(uid, str) else uid


### PR DESCRIPTION
## 修复

此前插件通过 `context.get_config().get("admins_id", [])` 直接拿到 AstrBot 全局 `admins_id` 列表引用，并在 `_normalize_id()` 中原地清理非数字 ID。个人微信管理员 ID 形如 `xxx@im.wechat`，不是纯数字，因此会在插件加载后被移除，并可能在后续全局配置保存时写回 `cmd_config.json`，表现为重启后管理员 ID 丢失。

本次修改让 qzone 只保留一份本地数字管理员 ID 副本，用于 OneBot 私聊通知；插件自身的忽略群/用户列表仍保留数字化归一逻辑，但不再修改 AstrBot 全局管理员列表。

## 变更

- 避免 `PluginConfig.admins_id` 直接引用 AstrBot 全局 `admins_id`
- 新增 `_numeric_ids()` 统一处理 qzone 需要的纯数字 ID
- `_normalize_id()` 不再处理管理员列表，只处理插件自身 ignore 配置

## 测试

- 测试已通过

## Summary by Sourcery

通过隔离 qzone 插件的数字管理员 ID，并将规范化操作限制在本地忽略列表中，防止其修改 AstrBot 的全局管理员 ID 列表。

Bug Fixes:
- 在 qzone 插件初始化过程中，通过为 `admins_id` 使用仅包含数字的本地副本，避免删除非数字的全局管理员 ID（例如个人微信号）。

Enhancements:
- 引入一个辅助方法，用于为 qzone 一致地提取仅包含数字的 ID 列表，并在忽略列表规范化过程中复用该方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent the qzone plugin from mutating AstrBot's global admin ID list by isolating its numeric admin IDs and limiting normalization to local ignore lists.

Bug Fixes:
- Avoid deleting non-numeric global admin IDs (e.g., personal WeChat IDs) during qzone plugin initialization by using a local numeric-only copy for admins_id.

Enhancements:
- Introduce a helper to consistently extract numeric-only ID lists for qzone and reuse it in ignore list normalization.

</details>