### PR TITLE
fix: 空说说异常 + LLM vision 降级兼容

### DIFF
--- a/core/llm_action.py
+++ b/core/llm_action.py
@@ -263,12 +263,27 @@ class LLMAction:
             )
 
             logger.debug(prompt)
-            llm_response = await provider.text_chat(
-                system_prompt=system_prompt,
-                prompt=prompt,
-                contexts=contexts,
-                image_urls=post.images,
-            )
+            # 先尝试带图片调用，若 LLM 不支持 vision 则降级为纯文本
+            try:
+                llm_response = await provider.text_chat(
+                    system_prompt=system_prompt,
+                    prompt=prompt,
+                    contexts=contexts,
+                    image_urls=post.images if post.images else None,
+                )
+            except Exception as img_err:
+                err_msg = str(img_err).lower()
+                if "image_url" in err_msg or "image" in err_msg:
+                    logger.warning(
+                        f"当前 LLM 不支持 vision，降级为纯文本评论: {img_err}"
+                    )
+                    llm_response = await provider.text_chat(
+                        system_prompt=system_prompt,
+                        prompt=prompt,
+                        contexts=contexts,
+                    )
+                else:
+                    raise
             comment = re.sub(r"[\s\u3000]+", "", llm_response.completion_text).rstrip(
                 "。"
             )

--- a/core/service.py
+++ b/core/service.py
@@ -63,7 +63,8 @@ class PostService:
                 raise RuntimeError(self._map_feed_error(resp, target_id=target_id))
             msglist = resp.data.get("msglist") or []
             if not msglist:
-                raise RuntimeError(f"QQ {target_id} 暂无可见说说")
+                logger.info(f"QQ {target_id} 暂无可见说说（非错误，返回空列表）")
+                return []
             posts: list[Post] = QzoneParser.parse_feeds(msglist)
 
         else:


### PR DESCRIPTION
## 🔧 修复内容

### 1. service.py — 空说说不再抛 RuntimeError

当 QQ 号存在但无可见说说时，原是 `raise RuntimeError`，导致 AstrBot 管道层报 ERROR 堆栈。

空说说是正常情况 → 改为 `logger.info` + `return []`，调用方 for 循环自然跳过。

### 2. llm_action.py — image_urls 兼容纯文本 LLM

`generate_comment` 传了 `image_urls=post.images`，但用户配置的 LLM 可能是不支持 vision 的纯文本模型（如 DeepSeek），API 返回 `400: unknown variant 'image_url', expected 'text'`。

修复: 先尝试带图片调用，若报 image 相关错误则自动降级为纯文本调用。

## 测试
- [x] QQ 号存在但无可见说说 → 不再报 ERROR
- [x] 纯文本 LLM 生成评论 → 自动降级纯文本
- [x] 多模态 LLM 生成评论 → 正常带图片调用

Closes #N/A

## Summary by Sourcery

将空的 Qzone 动态视为正常情况，并使 LLM 评论生成兼容非视觉模型。

Bug Fixes:
- 将没有可见动态的 QQ 账号视为非错误情况，仅记录日志并返回空的动态列表。
- 当配置的模型不支持视觉输入时，从支持图像的 LLM 调用自动回退到仅文本调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle empty Qzone feeds as a normal case and make LLM comment generation compatible with non-vision models.

Bug Fixes:
- Treat QQ accounts with no visible posts as a non-error case by logging and returning an empty feed list.
- Add automatic fallback from image-enabled LLM calls to text-only calls when the configured model does not support vision inputs.

</details>